### PR TITLE
Revert "Revert "Ant script to convert Cordova src zips to installation-r...

### DIFF
--- a/corimf-settings-js.sample
+++ b/corimf-settings-js.sample
@@ -74,7 +74,7 @@ var PLATFORM_REPO = 'cordova-wp8',
     PLUGIN_COUNT = 19,
     PLUGINS = ['cordova-plugin-battery-status', 'cordova-plugin-camera', 'cordova-plugin-console', 'cordova-plugin-contacts', 'cordova-plugin-device', 'cordova-plugin-device-motion', 'cordova-plugin-device-orientation', 'cordova-plugin-dialogs', 'cordova-plugin-file', 'cordova-plugin-file-transfer', 'cordova-plugin-geolocation', 'cordova-plugin-globalization', 'cordova-plugin-inappbrowser', 'cordova-plugin-media', 'cordova-plugin-media-capture', 'cordova-plugin-network-information', 'cordova-plugin-splashscreen', 'cordova-plugin-statusbar', 'cordova-plugin-vibration'],
     PLATFORM_REPOS = ['cordova-android', 'cordova-blackberry', 'cordova-ios', 'cordova-windows', 'cordova-wp8', 'cordova-js'],
-	OTHER_REPOS = ['cordova-blackberry-plugins', 'cordova-cli', 'cordova-plugman', 'cordova-lib', 'cordova-coho'];
+	OTHER_REPOS = ['cordova-blackberry-plugins', 'cordova-cli', 'cordova-plugman', 'cordova-lib'];
 
 exports.PLATFORM_REPO = PLATFORM_REPO;
 exports.PROJECT_ONLY = PROJECT_ONLY;

--- a/corimf-settings.sample
+++ b/corimf-settings.sample
@@ -76,4 +76,4 @@ PLUGMAN_REPO=cordova-plugman
 PLUGIN_COUNT=19
 PLUGINS="cordova-plugin-battery-status cordova-plugin-camera cordova-plugin-console cordova-plugin-contacts cordova-plugin-device cordova-plugin-device-motion cordova-plugin-device-orientation cordova-plugin-dialogs cordova-plugin-file cordova-plugin-file-transfer cordova-plugin-geolocation cordova-plugin-globalization cordova-plugin-inappbrowser cordova-plugin-media cordova-plugin-media-capture cordova-plugin-network-information cordova-plugin-splashscreen cordova-plugin-vibration cordova-plugin-statusbar"
 PLATFORM_REPOS="cordova-android cordova-blackberry cordova-ios cordova-windows cordova-wp8 cordova-js"
-OTHER_REPOS="cordova-blackberry-plugins cordova-cli cordova-plugman cordova-lib cordova-coho"
+OTHER_REPOS="cordova-blackberry-plugins cordova-cli cordova-plugman cordova-lib"


### PR DESCRIPTION
...eady layout""

This reverts commit 3ed7fe95e32a37d873fa8a3ac95dead0741c1862.

Revert "Ant script to convert Cordova src zips to installation-ready
layout"

This reverts commit 25a2fc964fc706a043ee904e26ddb37a84f0343b.
- Reverting because adding cordova-coho to the settings errors out some other scripts, i.e. the catchup script. Just going to leave it as it was before. 
